### PR TITLE
Removes oq-hazardlib dependency

### DIFF
--- a/eqcat/isc_homogenisor.py
+++ b/eqcat/isc_homogenisor.py
@@ -40,12 +40,10 @@ from collections import OrderedDict
 from scipy.misc import derivative
 from datetime import date
 from math import exp, sqrt, sin, cos, atan2, pi
-from eqcat.utils import haversine
+from eqcat.utils import haversine, _prepare_coords
 
-from openquake.hazardlib.geo import geodetic
-from openquake.hazardlib.geo.geodetic import _prepare_coords
-
-
+#from openquake.hazardlib.geo import geodetic
+#from openquake.hazardlib.geo.geodetic import _prepare_coords
 
 def is_GCMTMw(magnitude):
     '''

--- a/eqcat/utils.py
+++ b/eqcat/utils.py
@@ -33,6 +33,22 @@ MARKER_LEAP = np.array([0, 31, 60, 91, 121, 152, 182,
 
 SECONDS_PER_DAY = 86400.0
 
+
+
+def _prepare_coords(lons1, lats1, lons2, lats2):
+    """
+    Convert two pairs of spherical coordinates in decimal degrees
+    to numpy arrays of radians. Makes sure that respective coordinates
+    in pairs have the same shape.
+    """
+    lons1 = np.array(np.radians(lons1))
+    lats1 = np.array(np.radians(lats1))
+    assert lons1.shape == lats1.shape
+    lons2 = np.array(np.radians(lons2))
+    lats2 = np.array(np.radians(lats2))
+    assert lons2.shape == lats2.shape
+    return lons1, lats1, lons2, lats2
+
 def decimal_year(year, month, day):
     """
     Allows to calculate the decimal year for a vector of dates 


### PR DESCRIPTION
The previous fix for the duplicate finding (https://github.com/GEMScienceTools/catalogue_toolkit/pull/15) introduced an OpenQuake hazardlib dependency in switching the distance checker from degrees to kilometres. As only one small function from the hazardlib is used here the dependency is removed and the function instead placed in the utils.py file
