### PR TITLE
Changes matplotlib font from Type 3 to Truetype

### DIFF
--- a/eqcat/catalogue_query_tools.py
+++ b/eqcat/catalogue_query_tools.py
@@ -42,6 +42,10 @@ except:
 # RESET Axes tick labels
 matplotlib.rc("xtick", labelsize=14)
 matplotlib.rc("ytick", labelsize=14)
+# Switch to Type 1 fonts
+matplotlib.rcParams["pdf.fonttype"] = 42
+matplotlib.rcParams["ps.fonttype"] = 42
+matplotlib.rcParams["ps.useafm"] = True
 
 class CatalogueDB(object):
     """


### PR DESCRIPTION
By default Matplotib uses Type 3 fonts in postscript/pdf images. These are not supported by some TeX compilers. Switching the default to TrueType
