### PR TITLE
Fixing missing year data

### DIFF
--- a/eqcat/catalogue_query_tools.py
+++ b/eqcat/catalogue_query_tools.py
@@ -353,7 +353,7 @@ class CatalogueSelector(object):
         idx = pd.Series(polypath.contains_points(np.column_stack([
             self.catalogue.origins["longitude"].values,
             self.catalogue.origins["latitude"].values])))
-        idx = idx & self.catalogue.origins["depth"].notnull()
+        #idx = idx & self.catalogue.origins["depth"].notnull()
         return self._select_by_origins(idx, select_type)
 
     def select_within_bounding_box(self, bounds, select_type="any"):

--- a/eqcat/isc_downloader.py
+++ b/eqcat/isc_downloader.py
@@ -201,11 +201,19 @@ class ISCBulletinUrl():
 
     else:
 
+      # Make sure the whole year is covered
+      self.SetField("StartMonth","01")
+      self.SetField("StartDay","01")
+      self.SetField("StartTime","00:00:00")
+      self.SetField("EndMonth","12")
+      self.SetField("EndDay","31")
+      self.SetField("EndTime","23:59:59")
+
       # Split download into several chunks
       StartYear = int(self.Request["StartYear"].split("=")[1])
       EndYear = int(self.Request["EndYear"].split("=")[1])
 
-      for SY in range(StartYear,EndYear,SplitYears):
+      for SY in range(StartYear,EndYear+1,SplitYears):
 
         EY = min([EndYear,SY+SplitYears-1])
         self.SetField("StartYear",SY)

--- a/eqcat/isc_downloader.py
+++ b/eqcat/isc_downloader.py
@@ -1,21 +1,25 @@
+# -*- coding: utf-8 -*-
 #
-# LICENSE
+# Copyright (C) 2010-2016 GEM Foundation
 #
-# Copyright (c) 2016 GEM Foundation
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# The Catalogue Toolkit is free software: you can redistribute
-# it and/or modify it under the terms of the GNU Affero General Public
-# License as published by the Free Software Foundation, either version
-# 3 of the License, or (at your option) any later version.
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
 #
 # You should have received a copy of the GNU Affero General Public License
-# with this download. If not, see <http://www.gnu.org/licenses/>
-
-#!/usr/bin/env/python
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+#
+# Author: Poggi Valerio
 
 """
 Utility to download the ISC catalogue from website.
-Version 29/09/2016
+Version 20/10/2016
 """
 
 import os
@@ -37,7 +41,7 @@ class ISCBulletinUrl():
 
     # Compulsory fields
     self.Request["CatalogueType"]           = "request=REVIEWED"
-    self.Request["OutputFormat"]            = "out_format=CATCSV"
+    self.Request["OutputFormat"]            = "out_format=ISF"
     self.Request["SearchAreaShape"]         = "searchshape=RECT"
     self.Request["RectangleBottomLatitude"] = "bot_lat=36"
     self.Request["RectangleTopLatitude"]    = "top_lat=48"
@@ -76,7 +80,7 @@ class ISCBulletinUrl():
     self.Request["PrimeOnly"]               = "prime_only="
     self.Request["IncludeMagnitudes"]       = "include_magnitudes=on"
     self.Request["IncludeHeaders"]          = "include_headers=on"
-    self.Request["IncludeComments"]         = "include_comments=on"
+    self.Request["IncludeComments"]         = "include_comments=off"
     self.Request["IncludeLinks"]            = "include_links=off"
 
   #---------------------------------------------------------------------------------------
@@ -134,6 +138,23 @@ class ISCBulletinUrl():
       self.SetField(Key,Value)
 
     ParFile.close()
+
+  #---------------------------------------------------------------------------------------
+
+  def SetSearchArea(self, Lat, Lon):
+
+    self.SetField("SearchAreaShape","RECT")
+    self.SetField("RectangleBottomLatitude",str(Lat[0]))
+    self.SetField("RectangleTopLatitude",str(Lat[1]))
+    self.SetField("RectangleLeftLongitude",str(Lon[0]))
+    self.SetField("RectangleRightLongitude",str(Lon[1]))
+
+  #---------------------------------------------------------------------------------------
+
+  def SetSearchTime(self, Year0, Year1):
+
+    self.SetField("StartYear",str(Year0))
+    self.SetField("EndYear",str(Year1))
 
   #---------------------------------------------------------------------------------------
 
@@ -242,3 +263,4 @@ class ISCBulletinUrl():
         CatFile.close()
     except:
       print "Warning: Cannot open output file...."
+

--- a/eqcat/isc_downloader.py
+++ b/eqcat/isc_downloader.py
@@ -2,20 +2,14 @@
 #
 # Copyright (C) 2010-2016 GEM Foundation
 #
-# OpenQuake is free software: you can redistribute it and/or modify it
-# under the terms of the GNU Affero General Public License as published
-# by the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# OpenQuake is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
+# The Catalogue Toolkit is free software: you can redistribute
+# it and/or modify it under the terms of the GNU Affero General Public
+# License as published by the Free Software Foundation, either version
+# 3 of the License, or (at your option) any later version.
 #
 # You should have received a copy of the GNU Affero General Public License
-# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+# with this download. If not, see <http://www.gnu.org/licenses/>
 #
-# Author: Poggi Valerio
 
 """
 Utility to download the ISC catalogue from website.


### PR DESCRIPTION
1) Minor modifications to the ISC-Downloader, about missing last-year information
2) Disabling null-depth filter in polygon selection; issue to be fixed
3) Added functionalities for quick search setup
4) Fixed a mistake on the license header
