### PR TITLE
Adds induced flag attribute to ISF Event object

### DIFF
--- a/eqcat/isc_homogenisor.py
+++ b/eqcat/isc_homogenisor.py
@@ -337,7 +337,8 @@ class Homogenisor(object):
         name_list = ['eventID', 'Agency', 'Identifier', 'year', 'month', 'day',
                      'hour', 'minute', 'second', 'timeError', 'longitude',
                      'latitude', 'SemiMajor90', 'SemiMinor90', 'ErrorStrike',
-                     'depth', 'depthError', 'magnitude', 'sigmaMagnitude']
+                     'depth', 'depthError', 'magnitude', 'sigmaMagnitude',
+                     'Anthropogenic']
         fid = open(filename, "wt")
         # Write header
         print >> fid, ",".join(name_list)
@@ -370,6 +371,7 @@ class Homogenisor(object):
                                     _to_str(eqk.location.depth_error),
                                     str(eqk.magnitude),
                                     _to_str(eqk.magnitude_sigma),
+                                    str(event.induced_flag),
                                     event.magnitude_string()])
                 print >> fid, row_str
         fid.close()

--- a/eqcat/isf_catalogue.py
+++ b/eqcat/isf_catalogue.py
@@ -340,6 +340,7 @@ class Event(object):
         self.magnitudes = magnitudes
         self.description = description
         self.comment = ""
+        self.induced_flag = ""
 
     def number_origins(self):
         '''


### PR DESCRIPTION
Adds an attribute to an Event object within the ISF object indicating what type of induced activity it is (e.g. mining, geothermal, reservoir), should the event be flagged as induced according to one of the specified rejection keywords.