### PR TITLE
Adds residual analysis tools for regression

### DIFF
--- a/eqcat/gcmt_catalogue.py
+++ b/eqcat/gcmt_catalogue.py
@@ -113,7 +113,7 @@ class GCMTCentroid(object):
         """
         source_time = datetime.datetime.combine(self.date, self.time)
         second_diff = floor(fabs(time_diff))
-        microsecond_diff = int(1000. * (time_diff - second_diff))
+        microsecond_diff = int(1.0E6 * (time_diff - second_diff))
         if time_diff < 0.:
             source_time = source_time - datetime.timedelta(
                 seconds=int(second_diff), microseconds=microsecond_diff)
@@ -445,14 +445,15 @@ class GCMTCatalogue(object):
     :param int number_gcmts:
         Number of moment tensors in catalogue
     """
-    def __init__(self, start_year=None, end_year=None):
+    def __init__(self, start_year=None, end_year=None, gcmts=[]):
         """
         Instantiate catalogue class
         """
-        self.gcmts = []
-        self.number_gcmts = None
+        self.gcmts = gcmts
+        self.number_gcmts = len(gcmts)
         self.start_year = start_year
         self.end_year = end_year
+        self.ids = [gcmt.identifier for gcmt in self.gcmts]
 
     def number_events(self):
         '''
@@ -465,6 +466,22 @@ class GCMTCatalogue(object):
         Returns number of CMTs
         """
         return len(self.gcmts)
+
+    def __getitem__(self, key):
+        """
+        Returns a specific event by event ID
+        """
+        if key in self.ids:
+            return self.gcmts[self.ids.index(key)]
+        else:
+            raise KeyError("Event %s not found" % key)
+
+    def __iter__(self):
+        """
+        Iterates over the GCMTs
+        """
+        for gcmt in self.gcmts:
+            yield gcmt
 
    
     def gcmt_to_simple_array(self, centroid_location=True):

--- a/eqcat/isf_catalogue.py
+++ b/eqcat/isf_catalogue.py
@@ -466,6 +466,7 @@ class ISFCatalogue(object):
             self.events = events
         else:
             self.events = []
+        self.ids = [event.id for event in self.events]
 
 
     def __iter__(self):
@@ -481,12 +482,22 @@ class ISFCatalogue(object):
         """
         return self.get_number_events()
 
+    def __getitem__(self, key):
+        """
+        Returns the event corresponding to the specific key
+        """
+        if not len(self.ids):
+            self.ids = [event.id for event in self.events]
+        if key in self.ids:
+            return self.events[self.ids.index(key)]
+        else:
+            raise KeyError("Event %s not found" % key)
+
     def get_number_events(self):
         """
         Return number of events
         """
         return len(self.events)
-
 
     def get_event_key_list(self):
         """
@@ -496,7 +507,6 @@ class ISFCatalogue(object):
             return []
         else:
             return [eq.id for eq in self.events]
-
 
     def merge_second_catalogue(self, catalogue):
         '''

--- a/eqcat/parsers/converters.py
+++ b/eqcat/parsers/converters.py
@@ -182,7 +182,7 @@ class GCMTtoISFParser(object):
                                              gcmt.hypocentre.source, 
                                              scale='Ms'))
             m_w = Magnitude(event_id,
-                            gcmt.centroid.centroid_id, gcmt.magnitude, cat_id, 
+                            origin_id + "-C", gcmt.magnitude, cat_id, 
                             scale='Mw')
             #origin_mags.append(m_w)
             # Get locations


### PR DESCRIPTION
To explore trends in magnitudes with time and magnitude new tools are added to allow the user to visualise the residuals of a regression model with respect to magnitude and time, plus a "combination" plot showing a breakdown of the regression residuals.

Other additions include:
1. Refactor of "all" option for catalogue selection to improve speed
2. Minor changes to magnitude-agency selection for cleanup
3. Minor edits to GCMT parsers and GCMT to ISF converter to cleanup how the GCMT IDs are represented in the ISF format.
4. Adds __getitem__ and __iter__ containers to GCMT and ISF classes